### PR TITLE
rgw: fix empty json response when getting user quota

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -683,6 +683,7 @@ void RGWOp_Quota_Info::execute()
   if (http_ret < 0)
     return;
 
+  flusher.start(0);
   if (show_all) {
     UserQuotas quotas(info);
     encode_json("quota", quotas, s->formatter);


### PR DESCRIPTION
Fixes: #12117
Signed-off-by: wuxingyi wuxingyi@letv.com
(cherry picked from commit 64fceed2202c94edf28b8315fe14c9affa8c0116)
Signed-off-by: Dunrong Huang dunrong.huang@eayun.com
