### PR TITLE
rgw: fix build issue

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2387,12 +2387,10 @@ public:
     RGWUserInfo info;
 
     try {
-      decode_json_obj(uci, obj);
+      decode_json_obj(info, obj);
     } catch (JSONDecoder::err& e) {
       return -EINVAL;
     }
-
-    decode_json_obj(info, obj);
 
     RGWUserInfo old_info;
     time_t orig_mtime;


### PR DESCRIPTION
rgw/rgw_user.cc: In member function 'virtual int RGWUserMetadataHandler::put(RGWRados_, std::string&, RGWObjVersionTracker&, time_t, JSONObj_, RGWMetadataHandler::sync_type_t)':
rgw/rgw_user.cc:2390:23: error: 'uci' was not declared in this scope
       decode_json_obj(uci, obj);
                       ^

this bug is introduced by commit: 98e9a18e

Signed-off-by: isyippee yippee_liu@163.com
