### PR TITLE
rgw: fix bad origin in CORS request would cause the rgw to crash.

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -104,6 +104,8 @@ static bool is_string_in_set(set<string>& s, string h) {
         string sl = ssplit.front();
         dout(10) << "Finding " << sl << ", in " << h 
           << ", at offset not less than " << flen << dendl;
+        if (h.size() < sl.size())
+          continue;
         if (h.compare((h.size() - sl.size()), sl.size(), sl) != 0)
           continue;
         ssplit.pop_front();


### PR DESCRIPTION
when the length of the origin is less than the rule.

Fixes: #6331

Signed-off-by: LiuYang yippeetry@gmail.com
