### PR TITLE
rgw: realize inherit bucket's ACL

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1735,6 +1735,10 @@ void RGWPutObj::execute()
     }
   }
 
+  if (s->canned_acl.empty()) {
+    policy = *s->bucket_acl;
+  }
+
   policy.encode(aclbl);
 
   attrs[RGW_ATTR_ACL] = aclbl;


### PR DESCRIPTION
upload object, if you do not set ACL, use bucket's ACL.

Signed-off-by: LiuYang yippeetry@gmail.com
