### PR TITLE
librbd: fix return value overflow in rbd_discard.

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -357,7 +357,7 @@ int rbd_diff_iterate(rbd_image_t image,
 		     uint64_t ofs, uint64_t len,
 		     int (*cb)(uint64_t, size_t, int, void *), void *arg);
 ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len, const char *buf);
-int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
+ssize_t rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len, const char *buf, rbd_completion_t c);
 int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len, char *buf, rbd_completion_t c);
 int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len, rbd_completion_t c);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -181,7 +181,7 @@ public:
 		   uint64_t ofs, uint64_t len,
 		   int (*cb)(uint64_t, size_t, int, void *), void *arg);
   ssize_t write(uint64_t ofs, size_t len, ceph::bufferlist& bl);
-  int discard(uint64_t ofs, uint64_t len);
+  ssize_t discard(uint64_t ofs, uint64_t len);
 
   int aio_write(uint64_t off, size_t len, ceph::bufferlist& bl, RBD::AioCompletion *c);
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2695,7 +2695,7 @@ reprotect_and_return_err:
     return mylen;
   }
 
-  int discard(ImageCtx *ictx, uint64_t off, uint64_t len)
+  ssize_t discard(ImageCtx *ictx, uint64_t off, uint64_t len)
   {
     utime_t start_time, elapsed;
     ldout(ictx->cct, 20) << "discard " << ictx << " off = " << off << " len = "

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -178,7 +178,7 @@ namespace librbd {
   ssize_t read(ImageCtx *ictx, const vector<pair<uint64_t,uint64_t> >& image_extents,
 	       char *buf, bufferlist *pbl);
   ssize_t write(ImageCtx *ictx, uint64_t off, size_t len, const char *buf);
-  int discard(ImageCtx *ictx, uint64_t off, uint64_t len);
+  ssize_t discard(ImageCtx *ictx, uint64_t off, uint64_t len);
   int aio_write(ImageCtx *ictx, uint64_t off, size_t len, const char *buf,
 		AioCompletion *c);
   int aio_discard(ImageCtx *ictx, uint64_t off, uint64_t len, AioCompletion *c);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -471,7 +471,7 @@ namespace librbd {
     return librbd::write(ictx, ofs, len, bl.c_str());
   }
 
-  int Image::discard(uint64_t ofs, uint64_t len)
+  ssize_t Image::discard(uint64_t ofs, uint64_t len)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     return librbd::discard(ictx, ofs, len);
@@ -1081,7 +1081,7 @@ extern "C" ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
   return librbd::write(ictx, ofs, len, buf);
 }
 
-extern "C" int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len)
+extern "C" ssize_t rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   return librbd::discard(ictx, ofs, len);

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -735,6 +735,7 @@ written." % (self.name, ret, length))
         Trim the range from the image. It will be logically filled
         with zeroes.
         """
+        self.librbd.rbd_discard.restype = ctypes.c_ssize_t
         ret = self.librbd.rbd_discard(self.image,
                                       c_uint64(offset),
                                       c_uint64(length))


### PR DESCRIPTION
rbd_discard and librbd::discard both return int type value,
When discarding range is larger than 2<<31 (2G bytes), return
value will overflow.

pybind/rbd use ctypes to call librbd::rbd_discard and ctypes use
c_int as default return value type. When librbd::rbd_discard return
overflowed value, pybind/rbd will not work correctly either.

Signed-off-by: Zhao Chao zhaochao1984@gmail.com
