### PR TITLE
osd/ReplicatedPG: fix cache tier promotion for non-existent clone obj…

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -121,13 +121,14 @@ public:
     vector<snapid_t> snaps;  ///< src's snaps (if clone)
     snapid_t snap_seq;       ///< src's snap_seq (if head)
     librados::snap_set_t snapset; ///< src snapset (if head)
+    int list_snaps_ret;      ///< return value of list_snaps (if head)
     bool mirror_snapset;
     map<string, bufferlist> attrs; ///< src user attrs
     bool has_omap;
     CopyResults() : object_size(0), started_temp_obj(false),
 		    final_tx(NULL), user_version(0), 
-		    should_requeue(false), mirror_snapset(false),
-		    has_omap(false) {}
+		    should_requeue(false), list_snaps_ret(0),
+		    mirror_snapset(false), has_omap(false) {}
   };
 
   struct CopyOp {


### PR DESCRIPTION
…ect.

When doing list_snaps on an non-existent object in base pool, a whiteouted
object is created in the writeback cache tier, and an empty snapset is
attached to it. Then the list_snaps op succeeds and gets the empty snapset,
which makes librbd::DiffIterate work improperly.

This patch add return value of list_snaps to ReplicatedPG::CopyResults, and
also pass op->may_write() to ReplicatedPG::finishi_promote. A whiteouted
object is only created when the head object is not exist and if list_snaps
doesn't fail or the original op is write.

Fixes: #16890

Signed-off-by: Zhao Chao zhaochao1984@gmail.com
