### PR TITLE
ReplicatedPG::promote_object: check scrubber and block if necessary

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1696,6 +1696,19 @@ void ReplicatedPG::promote_object(OpRequestRef op, ObjectContextRef obc,
     obc = get_object_context(missing_oid, true);
   }
   dout(10) << __func__ << " " << obc->obs.oi.soid << dendl;
+  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
+    dout(10) << __func__ << " " << obc->obs.oi.soid
+	     << " blocked by scrub" << dendl;
+    if (op) {
+      waiting_for_active.push_back(op);
+      dout(10) << __func__ << " " << obc->obs.oi.soid
+	       << " placing op in waiting_for_active" << dendl;
+    } else {
+      dout(10) << __func__ << " " << obc->obs.oi.soid
+	       << " no op, dropping on the floor" << dendl;
+    }
+    return;
+  }
 
   PromoteCallback *cb = new PromoteCallback(op, obc, this);
   object_locator_t oloc(m->get_object_locator());

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1059,7 +1059,10 @@ protected:
    */
   void do_cache_redirect(OpRequestRef op, ObjectContextRef obc);
   /**
-   * This function starts up a copy from
+   * This function attempts to start a promote.  Either it succeeds,
+   * or places op on a wait list.  If op is null, failure means that
+   * this is a noop.  If a future user wants to be able to distinguish
+   * these cases, a return value should be added.
    */
   void promote_object(OpRequestRef op, ObjectContextRef obc,
 		      const hobject_t& missing_object);


### PR DESCRIPTION
Otherwise, we might attempt to promote into an in-progress scrub
interval causing 11156.  I would have added a return value to
promote_object(), but could not find an existing user which
cared to distinguish the cases, even with a null op passed.
All existing users are in maybe_handle_cache.  The ones which
pass a null op are for promoting the object in parallel
with a proxy -- a case where not actually performing the promote
does not really matter.

Fixes: #11156
Signed-off-by: Samuel Just sjust@redhat.com
(cherry picked from commit 65bb4df599541cd2e0f195b905f24f529e255c00)
(cherry picked from commit 110c35498942ea0feec395b6e7992f802dd740ce)
