### PR TITLE
ReplicatedPG: fail a non-blocking flush if the object is being scrubbed

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6381,6 +6381,19 @@ int ReplicatedPG::try_flush_mark_clean(FlushOpRef fop)
     return -EBUSY;
   }
 
+  if (!fop->blocking && scrubber.write_blocked_by_scrub(oid)) {
+    if (fop->op) {
+      dout(10) << __func__ << " blocked by scrub" << dendl;
+      requeue_op(fop->op);
+      requeue_ops(fop->dup_ops);
+      return -EAGAIN;    // will retry
+    } else {
+      osd->logger->inc(l_osd_tier_try_flush_fail);
+      cancel_flush(fop, false);
+      return -ECANCELED;
+    }
+  }
+
   // successfully flushed; can we clear the dirty bit?
   // try to take the lock manually, since we don't
   // have a ctx yet.


### PR DESCRIPTION
Fixes: #8011
Backport: firefly, giant
Signed-off-by: Samuel Just sjust@redhat.com
(cherry picked from commit 9b26de3f3653d38dcdfc5b97874089f19d2a59d7)
(cherry picked from commit f856739824bc271405a6fa35bdefc2bdc42c2f02)
